### PR TITLE
feat: add .graphqlconfig to fix webstorm graphql indexing

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,15 @@
+{
+  "name": "Flow Playground GraphQL Schema",
+  "schemaPath": "src/api/apollo/local.graphql",
+  "extensions": {
+    "endpoints": {
+      "Local GraphQL Endpoint": {
+        "url": "http://localhost:8080/query",
+        "headers": {
+          "user-agent": "JS GraphQL"
+        },
+        "introspect": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Webstorm didn't resolve references for GraphQL schema types, so I added a `.graphqlconfig` file that helps webstorm figure out where to find schema definition file. 